### PR TITLE
Fix align repo spec predicateType with policies repo

### DIFF
--- a/specs/github/repo.yaml
+++ b/specs/github/repo.yaml
@@ -4,7 +4,7 @@
 id: github.com/${ORG}/${REPO}
 name: github.com/${ORG}/${REPO}
 url: git+https://github.com/${ORG}/${REPO}
-type: http://github.com/carabiner-dev/snappy/specs/github/repo.yaml
+type: http://github.com/carabiner-dev/snappy/specs/repo.yaml
 endpoint: repos/${ORG}/${REPO}
 method:  GET
 mask:


### PR DESCRIPTION
The `specs/github/repo.yaml` spec was generating attestations with predicateType `http://github.com/carabiner-dev/snappy/specs/github/repo.yaml` but all policies in `carabiner-dev/policies` that consume repo attestations filter on `http://github.com/carabiner-dev/snappy/specs/repo.yaml`.

This caused a silent mismatch: AMPEL would collect the attestation but no policy tenet would ever match it, making every repo-based control fail even when the underlying data was correct.

Fixed by aligning the type field to match what the policies expect.