### PR TITLE
feat: add REST-based MFA builtin spec for GitHub orgs

### DIFF
--- a/specs/github/mfa-rest.yaml
+++ b/specs/github/mfa-rest.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+# SPDX-License-Identifier: Apache-2.0
+---
+id: github.com/${ORG}
+name: github.com/${ORG}
+url: https://api.github.com/orgs/${ORG}/members
+type: http://github.com/carabiner-dev/snappy/specs/github/mfa-rest.yaml
+endpoint: orgs/${ORG}/members?filter=2fa_disabled&per_page=100
+method: GET
+payload: array
+trimNL: true


### PR DESCRIPTION
Adds `specs/github/mfa-rest.yaml`, a REST-based alternative to the existing GraphQL `mfa.yaml` spec for checking MFA status in GitHub orgs.

- Queries `orgs/${ORG}/members?filter=2fa_disabled` via REST API
- Returns members without MFA enabled
- Produces predicateType `http://github.com/carabiner-dev/snappy/specs/github/mfa-rest.yaml`

## Why not the existing GraphQL mfa.yaml

The GraphQL `mfa.yaml` uses the `hasTwoFactorEnabled` field on `membersWithRole`, which requires elevated token permissions not typically available in CI GitHub App setups. The REST endpoint `orgs/{ORG}/members?filter=2fa_disabled` achieves the same check with standard `read:org` scope, making it broadly compatible with GitHub App tokens used in CI pipelines.