### PR TITLE
Let library consumers seed the API client and read the builtin specs

### DIFF
--- a/internal/cmd/snap.go
+++ b/internal/cmd/snap.go
@@ -94,7 +94,7 @@ func addSnap(parentCmd *cobra.Command, specsFS *embed.FS) {
 
 			var f io.ReadCloser
 			if strings.HasPrefix(opts.SpecPath, "builtin:") {
-				f, err = specsFS.Open("specs/" + strings.TrimPrefix(opts.SpecPath, "builtin:"))
+				f, err = specsFS.Open(strings.TrimPrefix(opts.SpecPath, "builtin:"))
 				if err != nil {
 					return fmt.Errorf("opening internal spec: %w", err)
 				}

--- a/main.go
+++ b/main.go
@@ -1,20 +1,16 @@
 package main
 
 import (
-	"embed"
-
 	"github.com/carabiner-dev/snappy/internal/cmd"
 	"github.com/carabiner-dev/snappy/pkg/github"
 	"github.com/carabiner-dev/snappy/pkg/gitlab"
 	"github.com/carabiner-dev/snappy/pkg/platform"
+	"github.com/carabiner-dev/snappy/specs"
 )
-
-//go:embed specs/*/*.yaml
-var SpecsFS embed.FS
 
 func main() {
 	platform.Register(github.NewFactory())
 	platform.Register(gitlab.NewFactory())
 
-	cmd.Execute(&SpecsFS)
+	cmd.Execute(&specs.FS)
 }

--- a/pkg/snap/snapper.go
+++ b/pkg/snap/snapper.go
@@ -28,6 +28,14 @@ type Options struct {
 
 	// SpecPath is the path to the spec file (used for auto-detection)
 	SpecPath string
+
+	// Client is a pre-built API client the snapper uses instead of creating
+	// one through the platform registry. Set it when the credentials come from
+	// somewhere other than the process environment — for example a server
+	// seeding each call with a short-lived installation token. When set, its
+	// platform also resolves the snapshot defaults unless Platform is set
+	// explicitly.
+	Client platform.Client
 }
 
 type Snapper struct {
@@ -44,6 +52,10 @@ func (s *Snapper) Take(ctx context.Context, spec *Spec) (*Snapshot, error) {
 
 	// Determine platform type
 	platformType := s.Options.Platform
+	if platformType == "" && s.Options.Client != nil {
+		// A pre-built client knows its platform.
+		platformType = s.Options.Client.Platform()
+	}
 	if platformType == "" {
 		// Try to detect from spec path first
 		if s.Options.SpecPath != "" {
@@ -71,10 +83,13 @@ func (s *Snapper) Take(ctx context.Context, spec *Spec) (*Snapshot, error) {
 		s.Options.ResponseHeaders = factory.DefaultResponseHeaders()
 	}
 
-	// Create client for the detected/specified platform
-	client, err := s.implementation.GetClient(platformType)
-	if err != nil {
-		return nil, fmt.Errorf("creating api client: %w", err)
+	// Use the pre-built client or create one for the detected/specified platform
+	client := s.Options.Client
+	if client == nil {
+		client, err = s.implementation.GetClient(platformType)
+		if err != nil {
+			return nil, fmt.Errorf("creating api client: %w", err)
+		}
 	}
 
 	resp, err := s.implementation.CallAPI(ctx, client, spec)

--- a/specs/embed.go
+++ b/specs/embed.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// Package specs embeds the builtin snapshot spec definitions so they can be
+// used both by the snappy CLI (the "builtin:" spec paths) and by programs
+// importing snappy as a library.
+package specs
+
+import "embed"
+
+// FS holds the builtin specs, keyed by platform: "github/repo.yaml",
+// "gitlab/project.yaml", and so on.
+//
+//go:embed github/*.yaml gitlab/*.yaml
+var FS embed.FS


### PR DESCRIPTION
This pull request introduces improvements to how built-in spec files are embedded and accessed, and adds support for injecting a pre-built API client into the snapshotting process. The changes enhance flexibility for both CLI and library use cases and improve the platform detection logic.

**Embedding and accessing built-in specs:**
- Moved the embedded spec files to a new `specs` package, exposing them via `specs.FS` for use in both the CLI and as a library. Updated the embedding pattern to target only specific subdirectories and YAML files. (`specs/embed.go`, `main.go`) [[1]](diffhunk://#diff-1ab6f219b7de850823cde0b1e0f56edf7cf1c8ba8790bbdad7c2be95dd4804c9R1-R15) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L4-R15)
- Fixed the path handling for opening built-in specs to match the new embedding structure, removing the redundant `"specs/"` prefix. (`internal/cmd/snap.go`)

**API client injection and platform detection:**
- Added a `Client` field to the `Options` struct in `pkg/snap/snapper.go`, allowing callers to provide a pre-built API client (useful for cases with custom authentication). (`pkg/snap/snapper.go`)
- Enhanced platform detection logic in `Snapper.Take` to infer the platform from the injected client if present, and modified client instantiation to use the provided client when available. (`pkg/snap/snapper.go`) [[1]](diffhunk://#diff-9d445f7f5fa3ed0bebe3eb19af5386128bbd6baf1874c1bbb0077b63e6447f09R55-R58) [[2]](diffhunk://#diff-9d445f7f5fa3ed0bebe3eb19af5386128bbd6baf1874c1bbb0077b63e6447f09L74-R93)