### PR TITLE
Update golangci-lint to v2.13

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.10
+          version: v2.13

--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -55,7 +55,7 @@ func (c *Client) Call(ctx context.Context, method, path string, body io.Reader) 
 	}
 
 	// Make request
-	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: Expected external input
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("making request: %w", err)
 	}


### PR DESCRIPTION
Bumps the golangci-lint version pinned in the repository's lint workflow(s) from v2.10 to v2.13.

Latest release: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1

Signed-off-by: Biner <biner@carabiner.dev>
